### PR TITLE
Support minWidth option

### DIFF
--- a/src/SlugInput.tsx
+++ b/src/SlugInput.tsx
@@ -141,7 +141,7 @@ class SlugInput extends React.Component<
                     radius={2}
                     flex={1}
                     style={{
-                      maxWidth: '30ch',
+                      minWidth: `${this.props.type.options?.minWidth ?? 30}ch`,
                       whiteSpace: 'nowrap',
                       overflow: 'hidden',
                       textOverflow: 'ellipsis',


### PR DESCRIPTION
This allows you to provide an option in your slug definition that controls the width of the base URL.

Fixes #1 