### PR TITLE
Provide Context to urlPrefix function

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,9 +65,9 @@ export default {
         input: SlugInput,
       },
       options: {
-        urlPrefix: (document) => `https://site.url/${document.lang}`,
+        urlPrefix: (document, context) => `https://site.url/${document.lang}`,
         // It could even be a promise! 🛑 Be careful: this will be triggered on every document change.
-        urlPrefix: async (document) => {
+        urlPrefix: async (document, context) => {
           const subPath = await getDocumentSubPath(document) // ficticious asynchronous method
           return `https://site.url/${subPath}`
         },

--- a/src/usePrefixLogic.ts
+++ b/src/usePrefixLogic.ts
@@ -34,7 +34,7 @@ export function usePrefixLogic(props: SlugInputProps) {
 
       if (typeof options?.urlPrefix === 'function') {
         try {
-          const value = await Promise.resolve(options.urlPrefix(doc))
+          const value = await Promise.resolve(options.urlPrefix(doc, sourceContext))
           setUrlPrefix(value)
           return
         } catch (error) {


### PR DESCRIPTION
This PR adds the sourceContext as an optional argument to the urlPrefix.

Purpose:
This allows access to context methods like `getClient` to be called in the prefix function (which is something we ran into migrating from V2). 